### PR TITLE
Updated in attempt to clean up dependencies.  We were getting all of …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,15 @@ configurations {
     iosdriver
     integrationTestCompile.extendsFrom testCompile
     integrationTestRuntime.extendsFrom testRuntime
+
+    configurations {
+        all*.exclude module: 'selenium-chrome-driver'
+        all*.exclude module: 'selenium-edge-driver'
+        all*.exclude module: 'selenium-htmlunit-driver'
+        all*.exclude module: 'selenium-firefox-driver'
+        all*.exclude module: 'selenium-ie-driver'
+        all*.exclude module: 'selenium-safari-driver'
+    }
 }
 
 dependencies {
@@ -52,6 +61,7 @@ dependencies {
     compile 'ch.qos.logback:logback-classic:1.1.2'
     compile "org.seleniumhq.selenium:selenium-java:$seleniumVersion"
     compile group: 'junit', name: 'junit', version: '4.11'
+
 
     compile("org.gebish:geb-spock:$gebVersion") {
         exclude module: "groovy"
@@ -63,7 +73,7 @@ dependencies {
         exclude module: "groovy-all"
     }
 
-    compile "io.selendroid:selendroid-standalone:$selendroidVersion"
+    compile 'org.json:json:20150729'
     compile "io.selendroid:selendroid-client:$selendroidVersion"
     compile "org.uiautomation:ios-client:$iosClientVersion"
     compile "io.appium:java-client:$appiumClientVersion"

--- a/src/main/groovy/geb/mobile/driver/GebMobileDriverFactory.groovy
+++ b/src/main/groovy/geb/mobile/driver/GebMobileDriverFactory.groovy
@@ -1,13 +1,11 @@
 package geb.mobile.driver
 
 import groovy.util.logging.Slf4j
-import io.appium.java_client.AppiumDriver
 import io.appium.java_client.android.AndroidDriver
 import io.appium.java_client.ios.IOSDriver
 import io.selendroid.SelendroidCapabilities
 import io.selendroid.SelendroidDriver
 import org.openqa.selenium.Platform
-import org.openqa.selenium.firefox.FirefoxDriver
 import org.openqa.selenium.remote.DesiredCapabilities
 import org.openqa.selenium.remote.LocalFileDetector
 import org.openqa.selenium.remote.RemoteWebDriver


### PR DESCRIPTION
…the browser clients even though we don't need them for this project.  Removed selendroid standalone from the compile dependencies and pulled in the one dependency it provided (json).  Removed unused imports in the driver factory.
