### PR TITLE
The no-scrollable (--) flag was running against the driver instead of…

### DIFF
--- a/src/main/groovy/geb/mobile/android/AndroidUIAutomatorNonEmptyNavigator.groovy
+++ b/src/main/groovy/geb/mobile/android/AndroidUIAutomatorNonEmptyNavigator.groovy
@@ -18,6 +18,8 @@ import org.openqa.selenium.WebElement
 @Slf4j
 class AndroidUIAutomatorNonEmptyNavigator extends AbstractMobileNonEmptyNavigator<AndroidDriver> {
 
+    public static final String SKIP_SCROLLING_INDICATOR = "--"
+
     AndroidUIAutomatorNonEmptyNavigator(Browser browser, Collection<? extends MobileElement> contextElements) {
         super(browser,contextElements)
     }
@@ -28,10 +30,9 @@ class AndroidUIAutomatorNonEmptyNavigator extends AbstractMobileNonEmptyNavigato
 
     @Override
     Navigator find(String selectorString) {
-        String oldSelectorString = "";
-        if (selectorString.startsWith("--")) {
-            oldSelectorString = selectorString
-            selectorString = selectorString.subSequence(2, selectorString.length())
+        boolean skipScrolling = selectorString.startsWith(SKIP_SCROLLING_INDICATOR)
+        if (skipScrolling) {
+            selectorString = selectorString.subSequence(SKIP_SCROLLING_INDICATOR.size(), selectorString.length())
         }
 
         By by = getByForSelector(selectorString)
@@ -41,13 +42,11 @@ class AndroidUIAutomatorNonEmptyNavigator extends AbstractMobileNonEmptyNavigato
         if (!contextElements || (by instanceof By.ByXPath)) {
             List<WebElement> found = driver.findElements(by)
             found && list.addAll(found)
-        } else if (oldSelectorString.startsWith("--")) {
-            list = driver.findElements(by)
         } else {
             contextElements?.each { WebElement element ->
                 List<WebElement> found = element.findElements(by)
 
-                if (!found && by instanceof MobileBy.ByAndroidUIAutomator) {
+                if (!skipScrolling && !found && by instanceof MobileBy.ByAndroidUIAutomator) {
                     // This is a temporary workaround for https://github.com/appium/appium/issues/5721
                     List<WebElement> scrollable = driver.findElements(MobileBy.AndroidUIAutomator("new UiSelector().scrollable(true)"))
 

--- a/src/test/groovy/geb/mobile/android/AndroidUIAutomatorNonEmptyNavigatorSpec.groovy
+++ b/src/test/groovy/geb/mobile/android/AndroidUIAutomatorNonEmptyNavigatorSpec.groovy
@@ -97,7 +97,7 @@ class AndroidUIAutomatorNonEmptyNavigatorSpec extends BaseMobileNonEmptyNavigato
         0 * _
     }
 
-    def 'not found - not ByAndroidUIAutomator' () {
+    def 'not found - not ByAndroidUIAutomator'() {
         given:
         String selector = '.android.widget.TextView'
 
@@ -111,7 +111,7 @@ class AndroidUIAutomatorNonEmptyNavigatorSpec extends BaseMobileNonEmptyNavigato
         0 * _
     }
 
-    def 'not found - ByAndroidUIAutomator - no scrollable' () {
+    def 'not found - ByAndroidUIAutomator - no scrollable'() {
         given:
         String selector = 'new UiSelector().clickable(true)'
 
@@ -126,7 +126,7 @@ class AndroidUIAutomatorNonEmptyNavigatorSpec extends BaseMobileNonEmptyNavigato
         0 * _
     }
 
-    def 'not found - ByAndroidUIAutomator - has scrollable' () {
+    def 'not found - ByAndroidUIAutomator - has scrollable'() {
         given:
         MobileElement mockMobileScrollable = Mock(MobileElement)
         String selector = 'new UiSelector().clickable(true)'
@@ -143,7 +143,7 @@ class AndroidUIAutomatorNonEmptyNavigatorSpec extends BaseMobileNonEmptyNavigato
         0 * _
     }
 
-    def 'multiple elements in context' () {
+    def 'multiple elements in context'() {
         given:
         MobileElement mockContextElement2 = Mock(MobileElement)
         MobileElement mockFoundElement2 = Mock(MobileElement)
@@ -160,6 +160,34 @@ class AndroidUIAutomatorNonEmptyNavigatorSpec extends BaseMobileNonEmptyNavigato
         1 * mockContextElement.findElements(MobileBy.AndroidUIAutomator(selector)) >> [mockFoundElement]
         1 * mockContextElement2.findElements(MobileBy.AndroidUIAutomator(selector)) >> [mockFoundElement2]
         1 * mockNavigatorFactory.createFromWebElements([mockFoundElement, mockFoundElement2])
+        0 * _
+    }
+
+    def 'skip scrollable - found'() {
+        given:
+        String selector = '--#com.test.different.app:id/id'
+
+        when:
+        navigator.find(selector)
+
+        then:
+        interaction { setupDefaultMocking() }
+        1 * mockContextElement.findElements(MobileBy.AndroidUIAutomator('resourceId("com.test.different.app:id/id")')) >> [mockFoundElement]
+        1 * mockNavigatorFactory.createFromWebElements([mockFoundElement])
+        0 * _
+    }
+
+    def 'skip scrollable - not found does not scroll'() {
+        given:
+        String selector = '--#com.test.different.app:id/id'
+
+        when:
+        navigator.find(selector)
+
+        then:
+        interaction { setupDefaultMocking() }
+        1 * mockContextElement.findElements(MobileBy.AndroidUIAutomator('resourceId("com.test.different.app:id/id")')) >> []
+        1 * mockNavigatorFactory.createFromWebElements([])
         0 * _
     }
 


### PR DESCRIPTION
… the context which caused selectors to lose the context when one existed, like when they were used within a module.
