### PR TITLE
Sauce labs cert work around

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -305,6 +305,7 @@ task uploadApk2Saucelabs(){
 
         try {
             logger.lifecycle "uploading appfile size:" + appFile?.bytes?.size()
+            sauceStorage.ignoreSSLIssues()
             sauceStorage.post(requestContentType: ContentType.BINARY, body: appFile.bytes)
         } catch (Exception e) {
             e.printStackTrace()


### PR DESCRIPTION
Sauce Labs Cert Workaround

https://support.saucelabs.com/hc/en-us/articles/115001710434-SNI-Support-Required-to-Validate-Sauce-Labs-Certificates

https://stackoverflow.com/questions/11638005/is-there-an-easier-way-to-tell-httpbuilder-to-ignore-an-invalid-cert

http://mspm1bapps1041:8080/user/acarstensen/my-views/view/CSTF/job/geb-mobile/42/console